### PR TITLE
Removed unsupported `SEPARATOR` fields

### DIFF
--- a/twitter-tools/custom-recipes/sonra_twitter_plugin_compute_followers_info/recipe.json
+++ b/twitter-tools/custom-recipes/sonra_twitter_plugin_compute_followers_info/recipe.json
@@ -31,7 +31,7 @@
             "type": "STRING",
             "mandatory" : true
         },
-        { "type" : "SEPARATOR", "label" : "Advanced" },
+        //{ "type" : "SEPARATOR", "label" : "Advanced" },
         {
             "name": "dataiku_url",
             "label" : "DSS URL",

--- a/twitter-tools/custom-recipes/sonra_twitter_plugin_compute_following_info/recipe.json
+++ b/twitter-tools/custom-recipes/sonra_twitter_plugin_compute_following_info/recipe.json
@@ -31,7 +31,7 @@
             "type": "STRING",
             "mandatory" : true
         },
-        { "type" : "SEPARATOR", "label" : "Advanced" },
+        //{ "type" : "SEPARATOR", "label" : "Advanced" },
         {
             "name": "dataiku_url",
             "label" : "DSS URL",

--- a/twitter-tools/custom-recipes/sonra_twitter_plugin_compute_users_from_keywords/recipe.json
+++ b/twitter-tools/custom-recipes/sonra_twitter_plugin_compute_users_from_keywords/recipe.json
@@ -51,7 +51,7 @@
             "type": "STRING",
             "mandatory" : true
         },
-        { "type" : "SEPARATOR", "label" : "Advanced" },
+        //{ "type" : "SEPARATOR", "label" : "Advanced" },
         {
             "name": "dataiku_url",
             "label" : "DSS URL",

--- a/twitter-tools/custom-recipes/sonra_twitter_plugin_follow/recipe.json
+++ b/twitter-tools/custom-recipes/sonra_twitter_plugin_follow/recipe.json
@@ -47,7 +47,7 @@
             "type": "STRING",
             "mandatory" : true
         },
-        { "type" : "SEPARATOR", "label" : "Advanced" },
+        //{ "type" : "SEPARATOR", "label" : "Advanced" },
         {
             "name": "dataiku_url",
             "label" : "DSS URL",

--- a/twitter-tools/custom-recipes/sonra_twitter_plugin_unfollow/recipe.json
+++ b/twitter-tools/custom-recipes/sonra_twitter_plugin_unfollow/recipe.json
@@ -47,7 +47,7 @@
             "type": "STRING",
             "mandatory" : true
         },
-        { "type" : "SEPARATOR", "label" : "Advanced" },
+        //{ "type" : "SEPARATOR", "label" : "Advanced" },
         {
             "name": "dataiku_url",
             "label" : "DSS URL",


### PR DESCRIPTION
I checked `Get followers info` recipe, it doesn't work with following code in recipe.json

{ "type" : "SEPARATOR", "label" : "Advanced" },

 according to this ( https://doc.dataiku.com/dss/latest/plugins/writing_reference.html ) page, SEPARATOR type is not allowed :(