### PR TITLE
Algoliasearch update

### DIFF
--- a/algoliasearch/Makefile
+++ b/algoliasearch/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=0.0.4
+PLUGIN_VERSION=0.0.5
 PLUGIN_ID=algoliasearch
 
 all:

--- a/algoliasearch/plugin.json
+++ b/algoliasearch/plugin.json
@@ -1,6 +1,6 @@
 {
     "id" : "algoliasearch",
-    "version" : "0.0.4",
+    "version" : "0.0.5",
     "meta" : {
         "label": "Algolia Search Connector",
         "description" : "A read-and-write connector for the Algolia search API",

--- a/algoliasearch/python-connectors/algoliasearch/connector.json
+++ b/algoliasearch/python-connectors/algoliasearch/connector.json
@@ -38,6 +38,12 @@
 			"label" :"Search settings",
 			"type":"TEXTAREA",
 			"description" : "Optional - As a JSON dict - See Algolia doc"
+		},
+		{
+			"name": "batchSize",
+			"label": "Batch size",
+			"type": "INT",
+			"defaultValue": 10000
 		}
 	]
 }

--- a/algoliasearch/python-connectors/algoliasearch/connector.json
+++ b/algoliasearch/python-connectors/algoliasearch/connector.json
@@ -20,7 +20,6 @@
 			"type" : "STRING",
 			"mandatory" : true
 		},
-
 		{
 			"name" : "index",
 			"label" : "Index name",
@@ -44,6 +43,13 @@
 			"label": "Batch size",
 			"type": "INT",
 			"defaultValue": 10000
+		},
+		{
+			"name": "payloadMaxSize",
+			"label": "Payload size limit in bytes",
+			"type": "INT",
+			"defaultValue": 0,
+			"description": "Truncate record to fit Algolia max size limit (Default: 0, no truncation)"
 		}
 	]
 }

--- a/algoliasearch/python-connectors/algoliasearch/connector.py
+++ b/algoliasearch/python-connectors/algoliasearch/connector.py
@@ -119,9 +119,6 @@ class AlgoliaSearchConnectorWriter(CustomDatasetWriter):
     def write_row(self, row):
         obj = {}
         for (col, val) in zip(self.dataset_schema["columns"], row):
-            #logging.info("Write %s for %s" % (val, col))
-            if len(unicode(val)) > 8000:   #algolia.com/doc/faq/basics/is-there-a-size-limit-for-my-index-records : 10KB
-                val = unicode(val)[0:7995] + '(...)'
             if col['type'] in ['tinyint', 'smallint', 'int', 'bigint']:
                 try:
                     val = int(val)

--- a/algoliasearch/python-connectors/algoliasearch/connector.py
+++ b/algoliasearch/python-connectors/algoliasearch/connector.py
@@ -50,7 +50,7 @@ class AlgoliaSearchConnector(Connector):
 
             print "Searching with facets: %s" % ",".join(facetFilters)
             if search_settings.get("facetFilters", None) is not None:
-                search_settings["facetFilters"] = search_settings["facetFilters"] + "," +",".join(facetFilters)
+                search_settings["facetFilters"] = search_settings["facetFilters"] + "," + ",".join(facetFilters)
             else:
                 search_settings["facetFilters"] = facetFilters
 
@@ -105,6 +105,7 @@ class AlgoliaSearchConnectorWriter(CustomDatasetWriter):
         self.dataset_schema = dataset_schema
         self.dataset_partitioning = dataset_partitioning
         self.partition_id = partition_id
+        self.batch_size = int(config["batchSize"])
 
         self.buffer = []
 
@@ -135,7 +136,7 @@ class AlgoliaSearchConnectorWriter(CustomDatasetWriter):
                 except Exception, e:
                     logging.warning("Failed to parse data as JSON col=%s val=%s err=%s" % (col["name"], val, e))
             obj[col["name"]] = val
-            if col["name"] =="id":
+            if col["name"] == "id":
                 logging.info("Set ObjectID")
                 obj["objectID"] = val
 
@@ -150,7 +151,7 @@ class AlgoliaSearchConnectorWriter(CustomDatasetWriter):
         logging.info("Final obj: %s" % obj)
         self.buffer.append(obj)
 
-        if len(self.buffer) > 50:
+        if len(self.buffer) >= self.batch_size:
             self.flush()
 
     def flush(self):

--- a/algoliasearch/python-connectors/algoliasearch/connector.py
+++ b/algoliasearch/python-connectors/algoliasearch/connector.py
@@ -124,6 +124,11 @@ class AlgoliaSearchConnectorWriter(CustomDatasetWriter):
                     val = int(val)
                 except Exception, e:
                     logging.warning("Failed to parse data as int col=%s val=%s err=%s" % (col["name"], val, e))
+            if col['type'] == 'boolean':
+                try:
+                    val = (val == 'true')
+                except Exception, e:
+                    logging.warning("Failed to parse data as int col=%s val=%s err=%s" % (col["name"], val, e))
             if col['type'] in ['array', 'object', 'map']:
                 try:
                     val = json.loads(val)

--- a/algoliasearch/python-connectors/algoliasearch/connector.py
+++ b/algoliasearch/python-connectors/algoliasearch/connector.py
@@ -77,7 +77,7 @@ class AlgoliaSearchConnector(Connector):
         index = self._get_index()
         res = index.search(self.config.get("searchQuery", ""), search_settings)
 
-        vals =[]
+        vals = []
 
         for dim in dataset_partitioning["dimensions"]:
             facet = res["facets"][dim["name"]]
@@ -106,6 +106,7 @@ class AlgoliaSearchConnectorWriter(CustomDatasetWriter):
         self.dataset_partitioning = dataset_partitioning
         self.partition_id = partition_id
         self.batch_size = int(config["batchSize"])
+        self.payload_max_size = int(config["payloadMaxSize"])
 
         self.buffer = []
 
@@ -120,6 +121,12 @@ class AlgoliaSearchConnectorWriter(CustomDatasetWriter):
     def write_row(self, row):
         obj = {}
         for (col, val) in zip(self.dataset_schema["columns"], row):
+            # Truncate cell value to fit Algolia's record size limit. Skipped by default.
+            # See https://www.algolia.com/doc/faq/basics/is-there-a-size-limit-for-my-index-records/
+            if self.payload_max_size > 0 and len(unicode(val)) > (self.payload_max_size - 2000):
+                logging.warning("Algolia payload max size reached, truncating record")
+                max_size = self.payload_max_size - 5
+                val = unicode(val)[0:max_size] + '(...)'
             if col['type'] in ['tinyint', 'smallint', 'int', 'bigint']:
                 try:
                     val = int(val)
@@ -148,7 +155,7 @@ class AlgoliaSearchConnectorWriter(CustomDatasetWriter):
                 logging.info("Forcing partitioning dim: %s=%s" % (dim["name"], id_chunks[idx]))
                 idx += 1
 
-        logging.info("Final obj: %s" % obj)
+        logging.debug("Final obj: %s" % obj)
         self.buffer.append(obj)
 
         if len(self.buffer) >= self.batch_size:


### PR DESCRIPTION
Small update on the `algoliasearch` plugin:
- [x] Remove the object size limit since it's not the same limit for all users (and it's better to let it handled/reject by the Algolia API itself)
- [x] Fix the boolean type not being recognized as it by Algolia
- [x] Allow custom batch size for indexing operations with a default to 10k objects, which drasticillay decrease the processing/indexing time

With ❤️ from Algolia!