### PR TITLE
Snowflake connection type fix

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -25,7 +25,7 @@ The Plugin allows DSS to create new Snowflake tables and to perform a fast bulkl
  
 ## Prerequisites
 
-* [Snowflake (JDBC) Connection](https://doc.dataiku.com/dss/latest/connecting/sql/snowflake.html) set up in DSS
+* [Snowflake Connection](https://doc.dataiku.com/dss/latest/connecting/sql/snowflake.html) set up in DSS (either as a generic JDBC connection or as a Snowflake connection)
 * [Amazon S3 Connection](https://doc.dataiku.com/dss/latest/connecting/s3.html) set up in DSS
 * the corresponding AWS credentials for the S3 buckets (AWS Access Key and AWS Secret Key)
 
@@ -44,7 +44,7 @@ Finally, the Plugin has been tested with Python 3.6 and requires a valid Python 
 
 In order to use the Plugin:
 
-* Defined a DSS S3 Dataset
+* Define a DSS S3 Dataset
 * Add the Plugin to your Flow
 * Set the S3 Dataset as Input of the Plugin (mandatory - only S3 is supported)
 * Assign a name for the output Dataset, stored in your Snowflake Connection

--- a/snowflake/custom-recipes/python-custom-recipes/recipe.py
+++ b/snowflake/custom-recipes/python-custom-recipes/recipe.py
@@ -85,9 +85,9 @@ connection_settings = {}
 def find_best_property_value(key, connectionParams, connectionProperties, urlComponents):
     if key in connectionParams and connectionParams[key]:
         return connectionParams[key]
-    propertyKv = next(prop for prop in connectionProperties if prop["name"] == key)
-    if propertyKv and propertyKv["value"]:
-        return propertyKv["value"]
+    for prop in connectionProperties:
+        if prop["name"] == key and prop["value"]:
+            return prop["value"]
     if key in urlComponents and urlComponents[key][0]:
         return urlComponents[key][0]
     return None

--- a/snowflake/custom-recipes/python-custom-recipes/recipe.py
+++ b/snowflake/custom-recipes/python-custom-recipes/recipe.py
@@ -106,34 +106,6 @@ sf_schema    = find_best_property_value("schema", params, properties, components
 sf_warehouse = find_best_property_value("warehouse", params, properties, components)
 sf_account   = urlparse.urlparse(jdbc_url).path.replace("snowflake://", "").replace(".snowflakecomputing.com", "")
 
-
-if config["info"]["databaseType"] == "JDBC":
-    jdbc_url = config["info"]["connectionParams"]["jdbcurl"]
-    components = urlparse.parse_qs(urlparse.urlparse(jdbc_url).query)
-    properties = config["info"]["connectionParams"]["properties"]
-    user, password = config["info"]["connectionParams"]["user"], config["info"]["connectionParams"]["password"]
-
-    connection_settings['user'] = user
-    if not connection_settings['user']:
-        user_property = next(prop for prop in properties if prop["name"] == "user")["value"]
-    if not connection_settings['user']:
-        connection_settings['user'] = components["user"][0]
-
-    connection_settings['password'] = password
-    if not connection_settings['password']:
-        user_property = next(prop for prop in properties if prop["name"] == "password")["value"]
-    if not connection_settings['password']:
-        connection_settings['password'] = components["password"][0]
-    
-
-
-sf_user      = components["user"][0]
-sf_password  = components["password"][0]
-sf_database  = components["db"][0]
-sf_schema    = components["schema"][0]
-sf_warehouse = components["warehouse"][0]
-sf_account   = urlparse.urlparse(jdbc_url).path.replace("snowflake://", "").replace(".snowflakecomputing.com", "")
-
 output_table = config["info"]["table"].replace("${projectKey}", project_key)
 
 

--- a/snowflake/plugin.json
+++ b/snowflake/plugin.json
@@ -1,6 +1,6 @@
 {
     "id" : "snowflake",
-    "version" : "0.1.1",
+    "version" : "0.1.2",
     
     "meta" : {
         "label" : "Snowflake",


### PR DESCRIPTION
This fixes two issues with the Snowflake plugin:

1. Adds support for the new `Snowflake` database connection type (originally only supported a generic `JDBC` type)
2. Looks at all possible parameter locations for a connection string. Previously it _only_ looked at the query string of `jdbcurl`. It now looks for high-level connection properties, then for JDBC properties, then at query string parameters (in order of preference). This fixes a security flaw with the current implementation that requires the user to put the password (unencrypted) in the query string.


![image](https://user-images.githubusercontent.com/939816/48623450-98f50100-e9a1-11e8-8860-52d4130f2a32.png)
