### PR TITLE
Macro to rebuild code-env

### DIFF
--- a/code-env-rebuild/plugin.json
+++ b/code-env-rebuild/plugin.json
@@ -1,0 +1,32 @@
+// This file is the descriptor for the DSS Plugin code-env-rebuild
+{
+    // The identifier of the plugin.
+    // This must be globally unique, and only contain A-Za-z0-9_-
+    // BEWARE: Changing this value is a dangerous operation and
+    // needs manual administrator intervention to fix directory names
+    "id" : "code-env-rebuild",
+
+    // Version. It is highly recommended to use Semantic Versioning
+    "version" : "0.0.1",
+
+
+    // Meta data for display purposes
+    "meta" : {
+        // Name of this plugin that appears in the interface.
+        "label" : "Plugin code-env-rebuild",
+
+        "description" : "A longer string explaining what the plugin does",
+        "author" : "duphan",
+
+        // The icon of a plugin must be one of the FontAwesome 3.1 icons
+        "icon" : "icon-puzzle-piece",
+
+        "licenseInfo" : "Apache Software License",
+
+        // URL where the user can learn more about the plugin
+        "url" : "https://www.dataiku.com",
+
+        // List of tags for filtering the list of plugins
+        "tags" : ["nicedataset", "dev"]
+    }
+}

--- a/code-env-rebuild/plugin.json
+++ b/code-env-rebuild/plugin.json
@@ -13,10 +13,10 @@
     // Meta data for display purposes
     "meta" : {
         // Name of this plugin that appears in the interface.
-        "label" : "Plugin code-env-rebuild",
+        "label" : "Code-env rebuild macro",
 
         "description" : "Rebuild plugin managed code envs",
-        "author" : "duphan",
+        "author" : "Dataiku (Du Phan)",
 
         // The icon of a plugin must be one of the FontAwesome 3.1 icons
         "icon" : "icon-puzzle-piece",
@@ -27,6 +27,6 @@
         "url" : "https://www.dataiku.com",
 
         // List of tags for filtering the list of plugins
-        "tags" : ["nicedataset", "dev"]
+        "tags" : ["macro", "code-env"]
     }
 }

--- a/code-env-rebuild/plugin.json
+++ b/code-env-rebuild/plugin.json
@@ -15,7 +15,7 @@
         // Name of this plugin that appears in the interface.
         "label" : "Plugin code-env-rebuild",
 
-        "description" : "A longer string explaining what the plugin does",
+        "description" : "Rebuild plugin managed code envs",
         "author" : "duphan",
 
         // The icon of a plugin must be one of the FontAwesome 3.1 icons

--- a/code-env-rebuild/plugin.json
+++ b/code-env-rebuild/plugin.json
@@ -1,32 +1,13 @@
-// This file is the descriptor for the DSS Plugin code-env-rebuild
 {
-    // The identifier of the plugin.
-    // This must be globally unique, and only contain A-Za-z0-9_-
-    // BEWARE: Changing this value is a dangerous operation and
-    // needs manual administrator intervention to fix directory names
     "id" : "code-env-rebuild",
-
-    // Version. It is highly recommended to use Semantic Versioning
     "version" : "0.0.1",
-
-
-    // Meta data for display purposes
     "meta" : {
-        // Name of this plugin that appears in the interface.
         "label" : "Code-env rebuild macro",
-
         "description" : "Rebuild plugin managed code envs",
         "author" : "Dataiku (Du Phan)",
-
-        // The icon of a plugin must be one of the FontAwesome 3.1 icons
-        "icon" : "icon-puzzle-piece",
-
+        "icon" : "icon-wrench",
         "licenseInfo" : "Apache Software License",
-
-        // URL where the user can learn more about the plugin
         "url" : "https://www.dataiku.com",
-
-        // List of tags for filtering the list of plugins
         "tags" : ["macro", "code-env"]
     }
 }

--- a/code-env-rebuild/python-runnables/rebuild-code-env/runnable.json
+++ b/code-env-rebuild/python-runnables/rebuild-code-env/runnable.json
@@ -1,60 +1,14 @@
-/* This file is the descriptor for the python runnable rebuild-code-env */
 {
-    /* Meta data for display purposes */
     "meta": {
         "label": "Rebuild code-envs",
         "description": "Rebuild all plugin managed code-envs to avoid version conflict of base packages when upgrading DSS.",
-        "icon": "icon-puzzle-piece"
+        "icon": "icon-wrench"
     },
-
-    /* whether the runnable's code is untrusted */
     "impersonate": false,
     "requiresGlobalAdmin": true,
-    /* list of required permissions on the project to see/run the runnable */
     "permissions": ["ADMIN"],
-
-    /* what the code's run() returns:
-       - NONE : no result
-       - HTML : a string that is a html (utf8 encoded)
-       - FOLDER_FILE : a (folderId, path) pair to a file in a folder of this project (json-encoded)
-       - FILE : raw data (as a python string) that will be stored in a temp file by DSS
-       - URL : a url
-     */
     "resultType": "RESULT_TABLE",
-
-    /* label to use when the runnable's result is not inlined in the UI (ex: for urls) */
     "resultLabel": "Result",
-
-    /* for FILE resultType, the extension to use for the temp file */
-    "extension": "txt",
-
-    /* for FILE resultType, the type of data stored in the temp file */
-    "mimeType": "text/plain",
-
-    /* Macro roles define where this macro will appear in DSS GUI. They are used to pre-fill a macro parameter with context.
-
-       Each role consists of:
-        - type: where the macro will be shown
-            * when selecting DSS object(s): DATASET, DATASETS, API_SERVICE, API_SERVICE_VERSION, BUNDLE, VISUAL_ANALYSIS, SAVED_MODEL, MANAGED_FOLDER
-            * in the global project list: PROJECT_MACROS
-        - targetParamsKey(s): name of the parameter(s) that will be filled with the selected object
-    */
-    "macroRoles": [
-     /* {
-            "type": "DATASET",
-            "targetParamsKey": "input_dataset"
-        } */
-    ],
-
-    /* The field "params" holds a list of all the params
-       for wich the user will be prompted for values:
-
-       The available parameter types are:
-       STRING, INT, DOUBLE, BOOLEAN, PASSWORD, SELECT, MAP, TEXTAREA,
-       DATASET, DATASETS, API_SERVICE, API_SERVICE_VERSION, BUNDLE, VISUAL_ANALYSIS, SAVED_MODEL, MANAGED_FOLDER
-    */
-    
-    "params": [
-                {}
-    ]
+    "macroRoles": [],
+    "params": [{}]
 }

--- a/code-env-rebuild/python-runnables/rebuild-code-env/runnable.json
+++ b/code-env-rebuild/python-runnables/rebuild-code-env/runnable.json
@@ -1,0 +1,60 @@
+/* This file is the descriptor for the python runnable rebuild-code-env */
+{
+    /* Meta data for display purposes */
+    "meta": {
+        "label": "Rebuild code-envs",
+        "description": "Rebuild all code-envs to avoid version conflict of base packages when upgrading DSS.",
+        "icon": "icon-puzzle-piece"
+    },
+
+    /* whether the runnable's code is untrusted */
+    "impersonate": false,
+    "requiresGlobalAdmin": true,
+    /* list of required permissions on the project to see/run the runnable */
+    "permissions": ["ADMIN"],
+
+    /* what the code's run() returns:
+       - NONE : no result
+       - HTML : a string that is a html (utf8 encoded)
+       - FOLDER_FILE : a (folderId, path) pair to a file in a folder of this project (json-encoded)
+       - FILE : raw data (as a python string) that will be stored in a temp file by DSS
+       - URL : a url
+     */
+    "resultType": "RESULT_TABLE",
+
+    /* label to use when the runnable's result is not inlined in the UI (ex: for urls) */
+    "resultLabel": "Result",
+
+    /* for FILE resultType, the extension to use for the temp file */
+    "extension": "txt",
+
+    /* for FILE resultType, the type of data stored in the temp file */
+    "mimeType": "text/plain",
+
+    /* Macro roles define where this macro will appear in DSS GUI. They are used to pre-fill a macro parameter with context.
+
+       Each role consists of:
+        - type: where the macro will be shown
+            * when selecting DSS object(s): DATASET, DATASETS, API_SERVICE, API_SERVICE_VERSION, BUNDLE, VISUAL_ANALYSIS, SAVED_MODEL, MANAGED_FOLDER
+            * in the global project list: PROJECT_MACROS
+        - targetParamsKey(s): name of the parameter(s) that will be filled with the selected object
+    */
+    "macroRoles": [
+     /* {
+            "type": "DATASET",
+            "targetParamsKey": "input_dataset"
+        } */
+    ],
+
+    /* The field "params" holds a list of all the params
+       for wich the user will be prompted for values:
+
+       The available parameter types are:
+       STRING, INT, DOUBLE, BOOLEAN, PASSWORD, SELECT, MAP, TEXTAREA,
+       DATASET, DATASETS, API_SERVICE, API_SERVICE_VERSION, BUNDLE, VISUAL_ANALYSIS, SAVED_MODEL, MANAGED_FOLDER
+    */
+    
+    "params": [
+                {}
+    ]
+}

--- a/code-env-rebuild/python-runnables/rebuild-code-env/runnable.json
+++ b/code-env-rebuild/python-runnables/rebuild-code-env/runnable.json
@@ -3,7 +3,7 @@
     /* Meta data for display purposes */
     "meta": {
         "label": "Rebuild code-envs",
-        "description": "Rebuild all code-envs to avoid version conflict of base packages when upgrading DSS.",
+        "description": "Rebuild all plugin managed code-envs to avoid version conflict of base packages when upgrading DSS.",
         "icon": "icon-puzzle-piece"
     },
 

--- a/code-env-rebuild/python-runnables/rebuild-code-env/runnable.py
+++ b/code-env-rebuild/python-runnables/rebuild-code-env/runnable.py
@@ -1,4 +1,3 @@
-# This file is the actual code for the Python runnable rebuild-code-env
 from dataiku.runnables import Runnable, ResultTable
 import dataiku
 import time
@@ -10,14 +9,9 @@ logging.basicConfig(level=logging.INFO,  # avoid getting log from 3rd party modu
 
 
 class MyRunnable(Runnable):
-    """The base interface for a Python runnable"""
 
     def __init__(self, project_key, config, plugin_config):
-        """
-        :param project_key: the project in which the runnable executes
-        :param config: the dict of the configuration of the object
-        :param plugin_config: contains the plugin settings
-        """
+
         self.project_key = project_key
         self.config = config
         self.plugin_config = plugin_config
@@ -25,18 +19,11 @@ class MyRunnable(Runnable):
         self.plugin_managed_envs = [c for c in self.client.list_code_envs() if c.get('deploymentMode') == 'PLUGIN_MANAGED']
         
     def get_progress_target(self):
-        """
-        If the runnable will return some progress info, have this function return a tuple of 
-        (target, unit) where unit is one of: SIZE, FILES, RECORDS, NONE
-        """
 
         return (len(self.plugin_managed_envs), "RECORDS")
 
     def run(self, progress_callback):
-        """
-        Do stuff here. Can return a string or raise an exception.
-        The progress_callback is a function expecting 1 value: current progress
-        """
+
         rt = ResultTable()
         rt.add_column("code_env", "Code-env", "STRING")
         rt.add_column("status", "Status", "STRING")

--- a/code-env-rebuild/python-runnables/rebuild-code-env/runnable.py
+++ b/code-env-rebuild/python-runnables/rebuild-code-env/runnable.py
@@ -1,0 +1,74 @@
+# This file is the actual code for the Python runnable rebuild-code-env
+from dataiku.runnables import Runnable, ResultTable
+import dataiku
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO,  # avoid getting log from 3rd party module
+                    format='code-envs-rebuild-macro %(levelname)s - %(message)s')
+
+
+class MyRunnable(Runnable):
+    """The base interface for a Python runnable"""
+
+    def __init__(self, project_key, config, plugin_config):
+        """
+        :param project_key: the project in which the runnable executes
+        :param config: the dict of the configuration of the object
+        :param plugin_config: contains the plugin settings
+        """
+        self.project_key = project_key
+        self.config = config
+        self.plugin_config = plugin_config
+        self.client = dataiku.api_client()
+        
+    def get_progress_target(self):
+        """
+        If the runnable will return some progress info, have this function return a tuple of 
+        (target, unit) where unit is one of: SIZE, FILES, RECORDS, NONE
+        """
+        return (len(self.client.list_code_envs()), "RECORDS")
+
+    def run(self, progress_callback):
+        """
+        Do stuff here. Can return a string or raise an exception.
+        The progress_callback is a function expecting 1 value: current progress
+        """
+        rt = ResultTable()
+        rt.add_column("code_env", "Code-env", "STRING")
+        rt.add_column("status", "Status", "STRING")
+        
+        for index, c in enumerate(self.client.list_code_envs()):
+            
+            env_name = c.get('envName')
+            env_lang = c.get('envLang')
+
+            progress_callback(index+1)
+            record = []
+            record.append(env_name)
+            
+            logger.info('Rebuilding {} ...'.format(env_name))
+            
+            try:
+                #save the config and drop the old code-env
+                old_env = self.client.get_code_env(env_lang, env_name)
+                env_def = old_env.get_definition()  
+                old_env.delete()
+
+                #rebuild the code-env
+                new_env = self.client.create_code_env(env_lang=env_lang, 
+                                                     env_name=env_name, 
+                                                     deployment_mode=env_def.get('desc').get('deploymentMode'), 
+                                                     params=env_def.get('desc'))
+                new_env.set_definition(env_def)
+                new_env.update_packages()
+                
+                record.append('Success')
+                rt.add_record(record)
+                
+            except Exception as e:
+                record.append('Failed: {}'.format(e)) #TODO: so we lost the code-env, what now ? ...
+                rt.add_record(record)
+        
+        return rt


### PR DESCRIPTION
When upgrading to 5.1, all plugin managed code-envs that have pandas 0.20 will break. This macro allows you to rebuild them so that your base packages is up-to-date with DSS.

Notes:
* You need to be `admin` to be able to run this macro.
* Need to test with MUS instance.
* The macro delete and then recreate the code-envs, if there is a problem in the process, especially after the delete phase, we lost the code-env -> Solution ? *(perhaps it is not that bad as users can always recreate it from the plugin)*