### PR TITLE
Adding git remote options to bundle migration macro

### DIFF
--- a/dataiku-project-bundle-migration/plugin.json
+++ b/dataiku-project-bundle-migration/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "dataiku-project-bundle-migration",
-    "version": "0.0.4",
+    "version": "1.0.0",
     "meta": {
         "label": "Push projects to automation",
         "description": "Bundle projects and push them to an automation node (or another Design node).",

--- a/dataiku-project-bundle-migration/python-runnables/dataiku_project_or_bundle_migration/runnable.json
+++ b/dataiku-project-bundle-migration/python-runnables/dataiku_project_or_bundle_migration/runnable.json
@@ -44,15 +44,69 @@
             "name": "activate_scenarios",
             "label" : "Activate Scenarios",
             "type": "BOOLEAN",
+            "mandatory" : false,
             "default": true,
             "description": "If selected, all active scenarios on the initial project will be activated in the remote project."
+        },
+        {
+            "name": "advanced",
+            "label" : "Advanced Options",
+            "type": "BOOLEAN",
+            "mandatory" : false,
+            "default": false,
+            "description": "View advanced options."
         },
         {
             "name": "ignore_ssl_certs",
             "label" : "Ignore SSL Certificates",
             "type": "BOOLEAN",
+            "visibilityCondition" : "model.advanced",
+            "mandatory" : false,
             "default": false,
             "description": "If selected, ignores SSL certificates on remote instance."
+        },
+        {
+            "name": "remote_design_instance",
+            "label" : "Remote Design Instance",
+            "type": "BOOLEAN",
+            "visibilityCondition" : "model.advanced",
+            "mandatory" : false,
+            "default": false,
+            "description": "Are you pushing the project to another design instance?"
+        },
+        {
+            "name": "create_bundle_on_remote_design_instance",
+            "label" : "Create Bundle on Remote Design Instance",
+            "type": "BOOLEAN",
+            "visibilityCondition" : "model.remote_design_instance",
+            "mandatory" : false,
+            "default": false,
+            "description": "If remote instance is a design instance, create a bundle on it?"
+        },
+        {
+            "name": "assign_git_remote",
+            "label" : "Git Remotes",
+            "type": "BOOLEAN",
+            "visibilityCondition" : "model.advanced",
+            "mandatory" : false,
+            "default": false,
+            "description": "Assign Git remote to target project."
+        },
+        {
+            "name": "git_remote_name",
+            "label": "Git Remote Name",
+            "type": "STRING",
+            "visibilityCondition" : "model.assign_git_remote",
+            "description": "Name of Git Remote Repository",
+            "mandatory": true
+        },
+        {
+            "name": "git_remote_url",
+            "label": "Git Remote URL",
+            "type": "STRING",
+            "visibilityCondition" : "model.assign_git_remote",
+            "description": "URL of Git Remote Repository",
+            "mandatory": true
         }
     ]
 }

--- a/dataiku-project-bundle-migration/python-runnables/dataiku_project_or_bundle_migration/runnable.py
+++ b/dataiku-project-bundle-migration/python-runnables/dataiku_project_or_bundle_migration/runnable.py
@@ -5,7 +5,8 @@ import dataiku
 import dataikuapi
 from dataiku.runnables import Runnable
 from dataikuapi.utils import DataikuException
-
+import os
+import re
 
 class MyRunnable(Runnable):
 
@@ -21,7 +22,43 @@ class MyRunnable(Runnable):
         
     def get_progress_target(self):
         return None
+    
+    def _get_next_git_remote_name_url(self, proj_git_config):
+        """
+        :param proj_git_config: the git config serialized text file for a project
+        """
+        git_remote_name = ''
+        url = ''
+        
+        # parse each line in the git config and return the next git remote name and corresponding url
+        for line in proj_git_config:
+            if line.startswith("[remote"):
+                git_remote_name = re.findall(r'"([^"]*)"', line)[0]
+                break
 
+        for line in proj_git_config:
+            try:
+                url = re.findall(r'url\s=\s(.+)',line)[0]
+                break
+            except:
+                continue
+        return git_remote_name, url
+    
+    def _get_git_remote_lines(self, name, url):
+        """
+        :param name: the git remote name
+        :param url: the git remote url
+        """
+        
+        # create lines of text to add to the new git config file
+        line_1 = '[remote "%s"]' % (name)
+        line_2 = "\turl = %s" % (url)
+        line_3 = "\tfetch = +refs/head/*:refs/remotes/%s/*" % (name)
+        
+        return {'line_1': line_1,
+                'line_2': line_2,
+                'line_3': line_3}
+    
     def run(self, progress_callback):
         
         # verify inputs
@@ -45,11 +82,11 @@ class MyRunnable(Runnable):
         
         # use public python api to get access to remote host
         remote_client = dataikuapi.DSSClient(remote_host, api_key)
-
-        # ignore SSL Certificates if selected
-        if self.config.get("ignore_ssl_certs"):
+        
+        ignore_ssl_certs = self.config.get("ignore_ssl_certs")
+        if ignore_ssl_certs:
             remote_client._session.verify = False
-
+        
         html = '<div> Successfully connected to remote host: %s</div>' %(remote_client.host)
         
         # get list of connections used in the initial project
@@ -120,12 +157,110 @@ class MyRunnable(Runnable):
                 if scenario_def['active']:
                     project_active_scenarios.append(scenario_def['id'])
         
+        # assign git remote on initial project if desired
+        assign_git_remote = self.config.get("assign_git_remote")
+        
+        os.environ['DKU_CURRENT_PROJECT_KEY'] = self.project_key
+   
+        if assign_git_remote:
+
+            new_git_remote_name = self.config.get("git_remote_name")
+            new_git_remote_url = self.config.get("git_remote_url")
+            
+            # get the path of remote git config files for this project
+            dss_data_dir = dataiku.get_custom_variables()["dip.home"]
+            path_to_git_remote_config = dss_data_dir + '/config/projects/' + self.project_key + '/.git/config'
+            
+            # count the number of existing git remotes for the initial project
+            with open(path_to_git_remote_config,"r") as project_git_config:
+                previous_remotes = 0
+                for line in project_git_config:
+                    if line.startswith("[remote"):
+                        previous_remotes += 1
+            
+            # store the name/url for each git remote for the initial project
+            with open(path_to_git_remote_config,"r") as project_git_config:
+                remotes_list = []
+                while previous_remotes > 0:
+                    remote_name, remote_url = self._get_next_git_remote_name_url(project_git_config)
+                    remotes_list.append({"name":remote_name,
+                                         "url":remote_url})
+                    previous_remotes -= 1
+            
+            git_remotes_config_lines = {}
+            existing_git_remote_counter = 0
+            
+            # if existing remotes, add their corresponding git config file text lines to a dictionary -- to store for later
+            if len(remotes_list) > 0:
+                git_remotes_config_lines['existing'] = []
+                for existing_git_remote in remotes_list:
+                    existing_git_remote_counter += 1
+                    single_git_remote_lines = self._get_git_remote_lines(existing_git_remote['name'], existing_git_remote['url'])
+                    git_remotes_config_lines['existing'].append(single_git_remote_lines)
+                
+            git_remotes_config_lines['new'] = self._get_git_remote_lines(new_git_remote_name, new_git_remote_url)
+            
+            # if existing remotes, then delete them from the initial project git config file
+            if len(remotes_list) > 0:
+                # read lines from initial file
+                with open(path_to_git_remote_config, "r") as project_git_config:
+                    git_remote_config_lines = project_git_config.readlines()
+
+                # delete all existing git remote lines
+                with open(path_to_git_remote_config, "w") as project_git_config:
+
+                    # iterate through each line in config
+                    for line in git_remote_config_lines:
+
+                        # iterate through each existing git remote
+                        for existing_git_remote in git_remotes_config_lines['existing']:
+
+                            # check if line not part of existing git remote -- only write back non-existing-remote lines
+                            if line.strip("\n") != existing_git_remote['line_1'] and line.strip("\n") != existing_git_remote['line_2'] and line.strip("\n") != existing_git_remote['line_3']:
+                                continue
+                            else:
+                                break
+                        else:
+                            project_git_config.write(line)
+            
+            
+            # open the (now empty) config file and append the new git remote lines
+            with open(path_to_git_remote_config, "a") as project_git_config:
+                project_git_config.write('{}\n{}\n{}\n'.format(git_remotes_config_lines['new']['line_1'], git_remotes_config_lines['new']['line_2'], git_remotes_config_lines['new']['line_3']))
+            
+            html += '<div> Git Remote Assigned on Initial Design Instance </div>'
+        
         # create the bundle (verify that the bundle_id does not exist)
         try:
             project.export_bundle(bundle_id)
             html += '<div><div>Successfully created bundle: %s</div>'  % (bundle_id)
         except DataikuException as de:
             error_msg = 'Failed - Bundle %s already exists for project %s' % (bundle_id, self.project_key)
+            
+            # FIX GIT REMOTE STUFF IF BUNDLE ACTIVATION FAILS
+            #if assigned a git remote to initial project, go back and delete it, and add back in initial git remotes
+            
+            if assign_git_remote:
+
+                # read lines from initial file
+                with open(path_to_git_remote_config, "r") as project_git_config:
+                    git_remote_config_lines = project_git_config.readlines()
+
+                # write back only the lines from before adding the remote
+                with open(path_to_git_remote_config, "w") as project_git_config:
+                    for line in git_remote_config_lines:
+                        if line.strip("\n") != git_remotes_config_lines['new']['line_1'] and line.strip("\n") != git_remotes_config_lines['new']['line_2'] and line.strip("\n") != git_remotes_config_lines['new']['line_3']:
+                            project_git_config.write(line)
+
+                html += '<div> Git Remote Deleted from Initial Design Instance </div>'
+
+                # open the config file and append the previous git remote lines
+                if len(remotes_list) > 0:
+                    with open(path_to_git_remote_config, "a") as project_git_config:
+                        for existing_git_remote in git_remotes_config_lines['existing']:
+                            project_git_config.write('{}\n{}\n{}\n'.format(existing_git_remote['line_1'], existing_git_remote['line_2'], existing_git_remote['line_3']))
+                    html += '<div> Initial Git Remotes added back to Initial Design Instance </div>'
+            
             raise Exception(error_msg)
         
         # check if there are any projects in remote instance
@@ -162,9 +297,37 @@ class MyRunnable(Runnable):
                 scenario_def['active'] = True
                 scenario.set_definition(scenario_def)
         
+        # check if remote instance is a design instance, and create a bundle on it if so
+        remote_design_instance = self.config.get("remote_design_instance")
+        
+        if remote_design_instance:
+            create_bundle_on_remote_design_instance = self.config.get("create_bundle_on_remote_design_instance")
+            if create_bundle_on_remote_design_instance:
+                remote_project.export_bundle(bundle_id)
+                html += '<div> Bundle Created on Remote Design Instance </div>'
+        
+        # if assigned a git remote to initial project, go back and delete it, and add back in initial git remotes
+        if assign_git_remote:
+            
+            # read lines from initial file
+            with open(path_to_git_remote_config, "r") as project_git_config:
+                git_remote_config_lines = project_git_config.readlines()
+            
+            # write back only the lines from before adding the remote
+            with open(path_to_git_remote_config, "w") as project_git_config:
+                for line in git_remote_config_lines:
+                    if line.strip("\n") not in git_remotes_config_lines['new']['line_1'] and line.strip("\n") not in git_remotes_config_lines['new']['line_2'] and line.strip("\n") not in git_remotes_config_lines['new']['line_3']:
+                        project_git_config.write(line)
+            
+            html += '<div> Git Remote Deleted from Initial Design Instance </div>'
+            
+            # open the config file and append the previous git remote lines
+            if len(remotes_list) > 0:
+                with open(path_to_git_remote_config, "a") as project_git_config:
+                    for existing_git_remote in git_remotes_config_lines['existing']:
+                        
+                        project_git_config.write('{}\n{}\n{}\n'.format(existing_git_remote['line_1'], existing_git_remote['line_2'], existing_git_remote['line_3']))
+                html += '<div> Initial Git Remotes added back to Initial Design Instance </div>'
+                
         html += '</div>'
         return html
-    
-    
-    
-    


### PR DESCRIPTION
This adds a new parameter allowing the user to add a project git remote to the remote project on the destination instance. It leaves existing git remotes on the initial design instance in tact.