### PR TITLE
Gutenberg Project Book: Update connector.py

### DIFF
--- a/gutenberg/python-connectors/gutenberg-project-book/connector.py
+++ b/gutenberg/python-connectors/gutenberg-project-book/connector.py
@@ -37,9 +37,14 @@ class GutenbergConnector(Connector):
         bid = str(self.book_id)
         print type(lid)
 
+        stopit = 0
         for i in range(lid-1):
-            url_book += '/'+bid[i]
-        url_book += '/'+ bid  + '/'+ bid + '.txt'
+            if (bid[i+1] != "-") and (stopit ==0):
+                url_book += '/'+bid[i]
+            else:
+                stopit=1
+                bidonly=bid[0:i]stopit = 0
+        url_book += '/'+ bidonly  + '/'+ bid + '.txt'
 
         print url_book
         response = url2.urlopen(url_book)

--- a/gutenberg/python-connectors/gutenberg-project-book/connector.py
+++ b/gutenberg/python-connectors/gutenberg-project-book/connector.py
@@ -43,7 +43,7 @@ class GutenbergConnector(Connector):
                 url_book += '/'+bid[i]
             else:
                 stopit=1
-                bidonly=bid[0:i]stopit = 0
+                bidonly=bid[0:i]
         url_book += '/'+ bidonly  + '/'+ bid + '.txt'
 
         print url_book


### PR DESCRIPTION
Couldn't get French version of Illiad by Homer (L'Illiade d'Homère id=14285) because text file is 
http://aleph.gutenberg.org/1/4/2/8/14285/14285-8.txt ( "minus 8" for iso8859-1 western europeen coding I guess)
so id is not read from first to n-1 digit or minus. I can get "L'Illiade" in DSS-DAtaiku with id:14285-8