### PR TITLE
Adding checkbox to ignore local proxy conf while pushing bundle

### DIFF
--- a/project-deployer/python-runnables/dataiku_project_or_bundle_migration/runnable.json
+++ b/project-deployer/python-runnables/dataiku_project_or_bundle_migration/runnable.json
@@ -55,6 +55,14 @@
             "description": "If selected, ignores SSL certificates on remote instance."
         },
         {
+            "name": "ignore_proxy_env_settings",
+            "label" : "Ignore Proxy settings",
+            "type": "BOOLEAN",
+            "mandatory" : false,
+            "default": false,
+            "description": "If you want to bypass your local proxy configuration"
+        },
+        {
             "name": "remote_design_instance",
             "label" : "Remote Design Instance",
             "type": "BOOLEAN",

--- a/project-deployer/python-runnables/dataiku_project_or_bundle_migration/runnable.py
+++ b/project-deployer/python-runnables/dataiku_project_or_bundle_migration/runnable.py
@@ -42,8 +42,8 @@ class MyRunnable(Runnable):
         ignore_proxy_conf = self.config.get("ignore_proxy_env_settings")
 
         if ignore_proxy_conf:
-            os.environ["http_proxy"] = ""
-            os.environ["https_proxy"] = ""
+            os.environ.pop('http_proxy', None)
+            os.environ.pop('https_proxy', None)
 
         # get client and connect to project
         client = dataiku.api_client()

--- a/project-deployer/python-runnables/dataiku_project_or_bundle_migration/runnable.py
+++ b/project-deployer/python-runnables/dataiku_project_or_bundle_migration/runnable.py
@@ -38,7 +38,13 @@ class MyRunnable(Runnable):
             raise Exception("API key is required")
 
         activate_scenarios = self.config.get("activate_scenarios")
-        
+
+        ignore_proxy_conf = self.config.get("ignore_proxy_env_settings")
+
+        if ignore_proxy_conf:
+            os.environ["http_proxy"] = ""
+            os.environ["https_proxy"] = ""
+
         # get client and connect to project
         client = dataiku.api_client()
         project = client.get_project(self.project_key)


### PR DESCRIPTION
This option is added for a customer that is facing proxy timeouts while pushing a bundle and that is unable to customize these timeouts (company level proxy). The idea is that they can be able to ignore the proxy configuration and communicate inside of a private VNET directly.