### PR TITLE
Fix packages and python versions

### DIFF
--- a/geocoder/Makefile
+++ b/geocoder/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=1.1.0
+PLUGIN_VERSION=1.1.1
 PLUGIN_ID=geocoder
 
 all:

--- a/geocoder/code-env/python/desc.json
+++ b/geocoder/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": [],
+  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON35", "PYTHON36"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false

--- a/geocoder/code-env/python/spec/requirements.txt
+++ b/geocoder/code-env/python/spec/requirements.txt
@@ -1,2 +1,2 @@
-geocoder
-diskcache
+geocoder==1.38.1
+diskcache~=4.0

--- a/geocoder/plugin.json
+++ b/geocoder/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "geocoder",
-    "version": "1.1.0",
+    "version": "1.1.1",
 
     "meta": {
         "label": "Geocoder",

--- a/geocoder/python-lib/cache_handler.py
+++ b/geocoder/python-lib/cache_handler.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 from diskcache import Cache
 
+
 class CacheHandler(Cache):
+
     def __init__(self, *args, **kwargs):
         self._enabled = kwargs.get('enabled', True)
 
         if self._enabled:
             super(CacheHandler, self).__init__(*args, **kwargs)
-
 
     def set(self, *args, **kwargs):
         if self._enabled:
@@ -15,19 +16,16 @@ class CacheHandler(Cache):
         return True
     __setitem__ = set
 
-
     def __exit__(self, *args, **kwargs):
         if self._enabled:
             super(CacheHandler, self).__exit__(*args, **kwargs)
 
-
     def __contains__(self, key):
-    	if self._enabled:
+        if self._enabled:
             return super(CacheHandler, self).__contains__(key)
         return False
 
-
     def __getitem__(self, key):
-    	if self._enabled:
+        if self._enabled:
             return super(CacheHandler, self).__getitem__(key)
         raise KeyError(key)


### PR DESCRIPTION
# Geocoder Plugin

Following [Slack conversation](https://dataiku.slack.com/archives/CDXH8V9PG/p1598277196066600), there was a mismatch between diskcache==5.0.1 and python 2.7. Corrected by added fixed version of packages geocoder and diskcache (geocoder==1.38.1 and diskcache~=4.0), explicit statement of the python versions in desc.json (support python 2.7, 3.5, 3.6). Tested on open street map with cache, worked fine.