### PR TITLE
[tableau-export-v2] Deprecate plugin

### DIFF
--- a/tableau-export-v2/Makefile
+++ b/tableau-export-v2/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=0.0.4
+PLUGIN_VERSION=0.0.5
 PLUGIN_ID=tableau-export-v2
 
 plugin:

--- a/tableau-export-v2/README.md
+++ b/tableau-export-v2/README.md
@@ -1,4 +1,4 @@
-# Tableau export (v2) plugin
+# Tableau TDE Export (deprecated)
 
 This plugin supersedes and deprecates the older "Tableau Export" plugin.
 

--- a/tableau-export-v2/plugin.json
+++ b/tableau-export-v2/plugin.json
@@ -1,9 +1,9 @@
 {
     "id": "tableau-export-v2",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "meta": {
-        "label": "Tableau export (v2)",
-        "description": "Export datasets to Tableau formats (TDE and Server)",
+        "label": "Tableau TDE Export (deprecated)",
+        "description": "Export datasets to TDE files and Tableau Server (deprecated, and superseded by “Tableau Hyper”)",
         "author": "Dataiku",
         "icon": "icon-tableau",
         "licenseInfo": "Apache Software License",


### PR DESCRIPTION
Update version number and state in name and description that this plugin is deprecated.