### PR TITLE
Enhancement/sas forward seekable stream

### DIFF
--- a/sas-format/code-env/python/desc.json
+++ b/sas-format/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36", "PYTHON35", "PYTHON37"],
+  "acceptedPythonInterpreters": ["PYTHON27", "PYTHON36"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false

--- a/sas-format/python-formats/sas/format.py
+++ b/sas-format/python-formats/sas/format.py
@@ -56,7 +56,7 @@ class SASFormatExtractor(FormatExtractor):
                         self.read(to_read)
 
             read_from = ForwardSeekStream(stream)
-        except ModuleNotFoundError:
+        except ImportError:
             read_from = stream
 
         if dump_to_file:

--- a/sas-format/python-formats/sas/format.py
+++ b/sas-format/python-formats/sas/format.py
@@ -1,66 +1,43 @@
-from dataiku.customformat import Formatter, OutputFormatter, FormatExtractor
-from dataiku.base.java_link import LinkedInputStream
-from collections import OrderedDict
-import pandas as pd
 import os
 import time
+from collections import OrderedDict
+
+import pandas as pd
+
+from dataiku.customformat import Formatter, FormatExtractor
 
 
 class SASFormatter(Formatter):
     def __init__(self, config, plugin_config):
         Formatter.__init__(self, config, plugin_config)
-        
+
     def get_output_formatter(self, stream, schema):
         raise NotImplementedError
-        
+
     def get_format_extractor(self, stream, schema=None):
-        return SASFormatExtractor(stream, schema, self.config)    
-
-
-# Fix for the stream class provided by DSS
-# Seek could be disabled by a one-liner like the following one but read_sas may seek forward
-# self.stream.seek = types.MethodType(lambda self, _: False, self.stream)
-class ForwardSeekStream(LinkedInputStream):
-    def __init__(self, stream):
-        LinkedInputStream.__init__(self, stream.link)
-        self.stream = stream
-        self.size_read = 0
-    
-    def readinto(self, b):
-        res = LinkedInputStream.readinto(self, b)
-        self.size_read += res
-        return res
-
-    def seek(self, seek, whence=0):    
-        to_read = seek if whence == 1 else seek - self.size_read
-                
-        if to_read < 0: 
-            raise IOError("Only forward seeking is supported")   
-        elif to_read > 0:
-            self.read(to_read)
+        return SASFormatExtractor(stream, schema, self.config)
 
 
 class SASFormatExtractor(FormatExtractor):
     def __init__(self, stream, schema, config):
         FormatExtractor.__init__(self, stream)
-        
+
         chunksize = int(config.get("chunksize", "10000"))
         sas_format = config.get("sas_format", "sas7bdat")
         encoding = config.get("encoding", "latin_1")
         dump_to_file = config.get("dump_to_file", False)
 
         self.hasSchema = schema != None
-
-        read_from = ForwardSeekStream(stream)
+        read_from = stream
 
         if dump_to_file:
             dirname, _ = os.path.split(os.path.abspath(__file__))
             fullpath = os.path.join(dirname, 'dumped-%s.sas7bdat' % (time.time()))
             with open(fullpath, 'w+') as of:
                 # Reading 500kb data everytime
-                for data in iter((lambda:stream.read(500000)), b''):
+                for data in iter((lambda: stream.read(500000)), b''):
                     of.write(data)
-                
+
             read_from = fullpath
 
         self.iterator = pd.read_sas(read_from,
@@ -70,27 +47,26 @@ class SASFormatExtractor(FormatExtractor):
                                     chunksize=chunksize)
 
         self.get_chunk()
-        
+
     def get_chunk(self):
         # Fix for previewing when using DSS < 4.1.X
         if self.hasSchema:
             self.chunk = next(self.iterator).to_dict('records')
         else:
-            self.chunk = [OrderedDict(row) for i, row in next(self.iterator).iterrows()]    
-            
+            self.chunk = [OrderedDict(row) for i, row in next(self.iterator).iterrows()]
+
         self.chunk_nb = 0
-        
+
     def read_schema(self):
         return [{"name": c.name, "type": "DOUBLE" if c.ctype == 'd' else "STRING"} for c in self.iterator.columns]
-    
+
     def read_row(self):
         try:
-            if self.chunk_nb >= len(self.chunk): 
+            if self.chunk_nb >= len(self.chunk):
                 self.get_chunk()
-                
+
             self.chunk_nb += 1
             return self.chunk[self.chunk_nb - 1]
 
         except StopIteration:
             return None
-        


### PR DESCRIPTION
[ch61914](https://app.clubhouse.io/dataiku/story/61914/make-javalink-exposed-stream-forward-seekable)

## Information for testing:
- Works for pre 9.0
- Doesn't work for 9.0 due to removed `LinkedInputStream` class
- Works for 9.0.1 and later, thanks to the fix in the java link

## MTP:
- install a SAS plugin from store for DSS 8.0
- Upload a demo file
- Select `SAS using Pandas` as format
- Click on Preview, make sure there's no error
- Repeat the same for 9.0.1, make sure there's an error
- Replace the plugin from the store with a plugin from this branch
- Repeat the test for 8.0 and 9.0.1, make sure they both work

## Test data:
[eventrepository.sas7bdat.zip](https://github.com/dataiku/dataiku-contrib/files/6189926/eventrepository.sas7bdat.zip)
