### PR TITLE
Fix how datasets are classified by the clear-intermediate-datasets macro

### DIFF
--- a/clear-intermediate-datasets/python-lib/utils.py
+++ b/clear-intermediate-datasets/python-lib/utils.py
@@ -6,4 +6,4 @@ def populate_result_table_with_list():
 def append_datasets_to_list(recipe_dict, list_to_append):
     # Append datasets' names from recipe's input or output dictionaries to an input or output list respectively
     for key in recipe_dict:
-        list_to_append += [x["ref"] for x in recipe_dict[key]["items"]]
+        list_to_append += [x["ref"] for x in recipe_dict[key]["items"] if x["ref"] not in list_to_append]

--- a/clear-intermediate-datasets/python-lib/utils.py
+++ b/clear-intermediate-datasets/python-lib/utils.py
@@ -1,0 +1,9 @@
+def populate_result_table_with_list():
+    # TODO
+    # Populate result table from list with arbitrary table size
+    return NotImplementedError()
+
+def append_datasets_to_list(recipe_dict, list_to_append):
+    # Append datasets' names from recipe's input or output dictionaries to an input or output list respectively
+    for key in recipe_dict:
+        list_to_append += [x["ref"] for x in recipe_dict[key]["items"]]

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -2,19 +2,10 @@ import dataiku
 import logging
 
 from dataiku.runnables import Runnable, ResultTable
+from utils import populate_result_table_with_list, append_datasets_to_list
 
 logging.basicConfig(format="%(asctime)s [%(levelname)s] %(message)s", level=logging.INFO)
 logging.getLogger().setLevel(logging.INFO)
-
-def populate_result_table_with_list():
-    # TODO
-    # Populate result table from list with arbitrary table size
-    return NotImplementedError()
-
-def append_datasets_to_list(recipe_dict, list_to_append):
-    # Append datasets' names from recipe's input or output dictionaries to an input or output list respectively
-    for key in recipe_dict:
-        list_to_append += [x["ref"] for x in recipe_dict[key]["items"]]
 
 class MyRunnable(Runnable):
     """The base interface for a Python runnable."""

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -61,20 +61,20 @@ class MyRunnable(Runnable):
         # Build deduplicated lists of input/output datasets:
         input_datasets = []
         output_datasets = []
-        for rcp in all_recipes:
-            rcp_inputs_dict = rcp["inputs"]
-            rcp_outputs_dict = rcp["outputs"]
+        for recipe in all_recipes:
+            recipe_inputs_dict = recipe["inputs"]
+            recipe_outputs_dict = recipe["outputs"]
             # CASE: no input dataset
-            if rcp_inputs_dict:
-                input_keys = list(rcp_inputs_dict.keys())
+            if recipe_inputs_dict:
+                input_keys = list(recipe_inputs_dict.keys())
                 for input_key in input_keys:
-                    rcp_inputs_list = [x["ref"] for x in rcp_inputs_dict[input_key]["items"]]
-                    input_datasets += rcp_inputs_list
-            output_keys = list(rcp_outputs_dict.keys())
+                    recipe_inputs_list = [x["ref"] for x in recipe_inputs_dict[input_key]["items"]]
+                    input_datasets += recipe_inputs_list
+            output_keys = list(recipe_outputs_dict.keys())
             for output_key in output_keys:
-                rcp_outputs_list = [x["ref"] for x in rcp_outputs_dict[output_key]["items"]]
+                recipe_outputs_list = [x["ref"] for x in recipe_outputs_dict[output_key]["items"]]
                 # Append them to the overall input list:
-                output_datasets += rcp_outputs_list
+                output_datasets += recipe_outputs_list
         # Deduplicate input/output lists:
         input_datasets = list(set(input_datasets))
         output_datasets = list(set(output_datasets))

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -68,7 +68,6 @@ class MyRunnable(Runnable):
             if recipe_inputs_dict:
                 for input_key in recipe_inputs_dict:
                     input_datasets += [x["ref"] for x in recipe_inputs_dict[input_key]["items"]]
-            output_keys = list(recipe_outputs_dict.keys())
             for output_key in recipe_outputs_dict:
                 output_datasets += [x["ref"] for x in recipe_outputs_dict[output_key]["items"]]
         # Deduplicate input/output lists:

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -63,9 +63,6 @@ class MyRunnable(Runnable):
             if recipe_inputs_dict:
                 append_datasets_to_list(recipe_inputs_dict, input_datasets)
             append_datasets_to_list(recipe_outputs_dict, output_datasets)
-        # Deduplicate input/output lists:
-        input_datasets = list(set(input_datasets))
-        output_datasets = list(set(output_datasets))
 
         # Identify Flow input/outputs & add them to result table:
         flow_inputs = [x for x in input_datasets if x not in output_datasets]

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -66,13 +66,15 @@ class MyRunnable(Runnable):
             rcp_outputs_dict = rcp["outputs"]
             # CASE: no input dataset
             if rcp_inputs_dict:
-                input_key = list(rcp_inputs_dict.keys())[0]
-                rcp_inputs_list = [x["ref"] for x in rcp_inputs_dict[input_key]["items"]]
-                input_datasets += rcp_inputs_list
-            output_key = list(rcp_outputs_dict.keys())[0]
-            rcp_outputs_list = [x["ref"] for x in rcp_outputs_dict[output_key]["items"]]
-            # Append them to the overall input list:
-            output_datasets += rcp_outputs_list
+                input_keys = list(rcp_inputs_dict.keys())
+                for input_key in input_keys:
+                    rcp_inputs_list = [x["ref"] for x in rcp_inputs_dict[input_key]["items"]]
+                    input_datasets += rcp_inputs_list
+            output_keys = list(rcp_outputs_dict.keys())
+            for output_key in output_keys:
+                rcp_outputs_list = [x["ref"] for x in rcp_outputs_dict[output_key]["items"]]
+                # Append them to the overall input list:
+                output_datasets += rcp_outputs_list
         # Deduplicate input/output lists:
         input_datasets = list(set(input_datasets))
         output_datasets = list(set(output_datasets))

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -11,7 +11,7 @@ def populate_result_table_with_list():
     # Populate result table from list with arbitrary table size
     return NotImplementedError()
 
-def append_datasets_in_dict_to_list(recipe_dict, list_to_append):
+def append_datasets_to_list(recipe_dict, list_to_append):
     # Append datasets' names from recipe's input or output dictionaries to an input or output list respectively
     for key in recipe_dict:
         list_to_append += [x["ref"] for x in recipe_dict[key]["items"]]
@@ -70,8 +70,8 @@ class MyRunnable(Runnable):
             recipe_outputs_dict = recipe["outputs"]
             # CASE: no input dataset
             if recipe_inputs_dict:
-                append_datasets_in_dict_to_list(recipe_inputs_dict, input_datasets)
-            append_datasets_in_dict_to_list(recipe_outputs_dict, output_datasets)
+                append_datasets_to_list(recipe_inputs_dict, input_datasets)
+            append_datasets_to_list(recipe_outputs_dict, output_datasets)
         # Deduplicate input/output lists:
         input_datasets = list(set(input_datasets))
         output_datasets = list(set(output_datasets))

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -11,6 +11,10 @@ def populate_result_table_with_list():
     # Populate result table from list with arbitrary table size
     return NotImplementedError()
 
+def append_datasets_in_dict_to_list(recipe_dict, list_to_append):
+    # Append datasets' names from recipe's input or output dictionaries to an input or output list respectively
+    for key in recipe_dict:
+        list_to_append += [x["ref"] for x in recipe_dict[key]["items"]]
 
 class MyRunnable(Runnable):
     """The base interface for a Python runnable."""
@@ -66,10 +70,8 @@ class MyRunnable(Runnable):
             recipe_outputs_dict = recipe["outputs"]
             # CASE: no input dataset
             if recipe_inputs_dict:
-                for input_key in recipe_inputs_dict:
-                    input_datasets += [x["ref"] for x in recipe_inputs_dict[input_key]["items"]]
-            for output_key in recipe_outputs_dict:
-                output_datasets += [x["ref"] for x in recipe_outputs_dict[output_key]["items"]]
+                append_datasets_in_dict_to_list(recipe_inputs_dict, input_datasets)
+            append_datasets_in_dict_to_list(recipe_outputs_dict, output_datasets)
         # Deduplicate input/output lists:
         input_datasets = list(set(input_datasets))
         output_datasets = list(set(output_datasets))

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -66,15 +66,11 @@ class MyRunnable(Runnable):
             recipe_outputs_dict = recipe["outputs"]
             # CASE: no input dataset
             if recipe_inputs_dict:
-                input_keys = list(recipe_inputs_dict.keys())
-                for input_key in input_keys:
-                    recipe_inputs_list = [x["ref"] for x in recipe_inputs_dict[input_key]["items"]]
-                    input_datasets += recipe_inputs_list
+                for input_key in recipe_inputs_dict:
+                    input_datasets += [x["ref"] for x in recipe_inputs_dict[input_key]["items"]]
             output_keys = list(recipe_outputs_dict.keys())
-            for output_key in output_keys:
-                recipe_outputs_list = [x["ref"] for x in recipe_outputs_dict[output_key]["items"]]
-                # Append them to the overall input list:
-                output_datasets += recipe_outputs_list
+            for output_key in recipe_outputs_dict:
+                output_datasets += [x["ref"] for x in recipe_outputs_dict[output_key]["items"]]
         # Deduplicate input/output lists:
         input_datasets = list(set(input_datasets))
         output_datasets = list(set(output_datasets))


### PR DESCRIPTION
**Updates:**
The previous version was only looking at the first key in both the _input_ and _output_ dictionaries of each recipe, so in some cases, with more than one type of input or output (_main_ vs _model_) only the datasets in the first key would be considered. See the behavior of the previous macro on the "Predicting Churn" project sample for an example of this issue.

**Considerations**
- Developed on DSS 10.0.0
- Tested on DSS 10.0.0 and 9.0.4