### PR TITLE
Update the result table output of the clear-intermediate-datasets macro

### DIFF
--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -6,6 +6,8 @@ from dataiku.runnables import Runnable, ResultTable
 logging.basicConfig(format="%(asctime)s [%(levelname)s] %(message)s", level=logging.INFO)
 logging.getLogger().setLevel(logging.INFO)
 
+
+
 def populate_result_table_with_list():
     # TODO
     # Populate result table from list with arbitrary table size
@@ -46,8 +48,12 @@ class MyRunnable(Runnable):
 
         # Initialize macro result table:
         result_table = ResultTable()
-        result_table.add_column("dataset", "dataset", "STRING")
-        result_table.add_column("status", "status", "STRING")
+        result_table.add_column("dataset", "Dataset", "STRING")
+        result_table.add_column("type", "Type", "STRING")
+        result_table.add_column("action", "Action", "STRING")
+        result_table.add_column("action_status", "Action Status", "STRING")
+
+        action_status = "Not done (Dry run)" if is_dry_run else "Done"
 
         client = dataiku.api_client()
         if self.config.get("project_key", None):
@@ -80,10 +86,10 @@ class MyRunnable(Runnable):
         # Identify Flow input/outputs & add them to result table:
         flow_inputs = [x for x in input_datasets if x not in output_datasets]
         for obj in flow_inputs:
-            result_table.add_record([obj, "KEEP(INPUT)"])
+            result_table.add_record([obj, "INPUT", "KEEP", action_status])
         flow_outputs = [x for x in output_datasets if x not in input_datasets]
         for obj in flow_outputs:
-            result_table.add_record([obj, "KEEP(OUTPUT)"])
+            result_table.add_record([obj, "OUTPUT", "KEEP", action_status])
         logging.info("Found {} FLOW INPUT datasets: {}".format(str(len(flow_inputs)),
                                                                str(flow_inputs)))
         logging.info("Found {} FLOW OUTPUT datasets: {}".format(str(len(flow_outputs)),
@@ -107,22 +113,27 @@ class MyRunnable(Runnable):
             to_keep += partd_datasets
             # Add them to result table:
             for obj in partd_datasets:
-                result_table.add_record([obj, "KEEP(PARTITIONED)"])
+                result_table.add_record([obj, "PARTITIONED", "KEEP", action_status])
         if keep_shared:
             to_keep += shared_datasets
             # Add them to result table:
             for obj in shared_datasets:
-                result_table.add_record([obj, "KEEP(SHARED)"])
+                result_table.add_record([obj, "SHARED", "KEEP", action_status])
         logging.info("Total of {} datasets to KEEP: {}".format(str(len(to_keep)),
                                                                str(to_keep)))
 
         # Perform cleanup or simulate it (dry run):
+        to_clear = []
+        for ds in all_datasets:
+            if ds["name"] not in to_keep:
+                result_table.add_record([ds["name"], "INTERMEDIATE", "CLEAR", action_status])
+                to_clear.append(ds["name"])
+        logging.info("Total of {} datasets TO CLEAR: {}".format(str(len(to_clear)),
+                                                               str(to_clear)))
         if not is_dry_run:
-            for ds in all_datasets:
-                ds_name = ds["name"]
-                if ds_name not in to_keep:
-                    dataset = project.get_dataset(ds_name)
-                    logging.info("Clearing {}...".format(ds_name))
-                    dataset.clear()
+            for ds in to_clear:
+                dataset = project.get_dataset(ds)
+                logging.info("Clearing {}...".format(ds))
+                dataset.clear()
 
         return result_table

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -6,8 +6,6 @@ from dataiku.runnables import Runnable, ResultTable
 logging.basicConfig(format="%(asctime)s [%(levelname)s] %(message)s", level=logging.INFO)
 logging.getLogger().setLevel(logging.INFO)
 
-
-
 def populate_result_table_with_list():
     # TODO
     # Populate result table from list with arbitrary table size


### PR DESCRIPTION
**Updates:**
All changes were done to the result table output of the macro:
- To improve clarity, the table now shows not only the datasets that will be kept but also those to clear
- The columns have been restructured for more clarity, including the state of the action (dry run vs done)

**Considerations**
- Developed on DSS 10.0.0
- Tested on DSS 10.0.0 and 9.0.4