### PR TITLE
Fix result table for shared & partitioned datasets

### DIFF
--- a/clear-intermediate-datasets/plugin.json
+++ b/clear-intermediate-datasets/plugin.json
@@ -4,7 +4,7 @@
     "meta": {
         "label": "Clear intermediate datasets",
         "description": "Save disk space by clearing intermediate datasets in the flow.",
-        "author": "Dataiku (Pierre Pfennig & Harizo Rajaona)",
+        "author": "Dataiku (Pierre Pfennig, Harizo Rajaona & Gonzalo Betegon)",
         "icon": "icon-trash",
         "licenseInfo": "Apache Software License",
         "url": "https://www.dataiku.com/dss/plugins/info/clear-intermediate-datasets.html",

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.json
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.json
@@ -45,7 +45,7 @@
             "name": "is_dry_run",
             "label" : "Dry run",
             "type": "BOOLEAN",
-            "default": true,
+            "defaultValue": true,
             "description":"Only lists the datasets to clear without performing data deletion.",
             "mandatory" : true
         },
@@ -53,14 +53,14 @@
             "name": "keep_partitioned",
             "label" : "Keep partitioned datasets",
             "type": "BOOLEAN",
-            "default": true,
+            "defaultValue": true,
             "mandatory" : true
         },
         {
             "name": "keep_shared",
             "label": "Keep shared datasets",
             "type": "BOOLEAN",
-            "default": true,
+            "defaultValue": true,
             "mandatory": true
         }
     ]

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.json
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.json
@@ -1,37 +1,13 @@
-/* This file is the descriptor for the python runnable Clear_intermediate_datasets */
 {
-    /* Meta data for display purposes */
     "meta" : {
         "label" : "Clear intermediate datasets",
         "description" : "Drop data from intermediate datasets of a Flow.",
         "icon" : "icon-trash"
     },
-
-    /* whether the runnable's code is untrusted */
     "impersonate" : false,
-
-    /* list of required permissions on the project to see/run the runnable */
     "permissions" : [],
-
-    /* what the code's run() returns:
-       - NONE : no result
-       - HTML : a string that is a html (utf8 encoded)
-       - FOLDER_FILE : a (folderId, path) pair to a file in a folder of this project (json-encoded)
-       - FILE : raw data (as a python string) that will be stored in a temp file by DSS
-       - URL : a url
-     */
     "resultType" : "RESULT_TABLE",
-
-    /* label to use when the runnable's result is not inlined in the UI (ex: for urls) */
     "resultLabel" : "my production",
-
-
-    /* The field "params" holds a list of all the params
-       for wich the user will be prompted for values:
-
-       The available parameter types are:
-       STRING, INT, DOUBLE, BOOLEAN, PASSWORD, SELECT, MAP, TEXTAREA
-    */
     "paramsPythonSetup": "get_projects.py",
     "params": [
         {

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.json
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.json
@@ -53,14 +53,14 @@
             "name": "keep_partitioned",
             "label" : "Keep partitioned datasets",
             "type": "BOOLEAN",
-            "default": false,
+            "default": true,
             "mandatory" : true
         },
         {
             "name": "keep_shared",
             "label": "Keep shared datasets",
             "type": "BOOLEAN",
-            "default": false,
+            "default": true,
             "mandatory": true
         }
     ]

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -100,7 +100,8 @@ class MyRunnable(Runnable):
         datasets = {"INPUT":flow_inputs,
             "OUTPUT":flow_outputs,
             "INTERMEDIATE": intermediate_datasets,
-            "SHARED": shared_datasets
+            "SHARED": shared_datasets,
+            "PARTITIONED": partitioned_datasets
            }
         
         for dataset_type, dataset_type_list in datasets.items():

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -77,6 +77,11 @@ class MyRunnable(Runnable):
         logging.info("Found {} FLOW OUTPUT datasets: {}".format(str(len(flow_outputs)),
                                                                 str(flow_outputs)))
 
+        # Identify Intermediate datasets:
+        intermediate_datasets = [x["name"] for x in all_datasets if x["name"] not in flow_inputs + flow_outputs]
+        logging.info("Found {} INTERMEDIATE datasets: {}".format(str(len(intermediate_datasets)),
+                                                                str(intermediate_datasets)))
+
         # Identify shared datasets:
         shared_objs = project.get_settings().settings["exposedObjects"]["objects"]
         shared_datasets = [x["localName"] for x in shared_objs if x["type"]=="DATASET"]
@@ -89,7 +94,25 @@ class MyRunnable(Runnable):
         logging.info("Found {} PARTITIONED datasets: {}".format(str(len(partd_datasets)),
                                                                 str(partd_datasets)))
 
-        # List all datasets to keep, potentially including shared & partd ones:
+        # Add dataset types to results list
+        results = []
+
+        for obj in flow_inputs:
+            results.append([obj, "INPUT"])
+
+        for obj in flow_outputs:
+            results.append([obj, "OUTPUT"])
+
+        for obj in intermediate_datasets:
+            results.append([obj, "INTERMEDIATE"])
+
+        for obj in partd_datasets:
+            results.append([obj, "PARTITIONED"])
+
+        for obj in shared_datasets:
+            results.append([obj, "SHARED"])
+
+        # Identify which datasets should be kept
         to_keep = flow_inputs + flow_outputs
         if keep_partitioned:
             to_keep += partd_datasets
@@ -98,44 +121,25 @@ class MyRunnable(Runnable):
         logging.info("Total of {} datasets to KEEP: {}".format(str(len(to_keep)),
                                                                str(to_keep)))
 
-        # Find intermediate datasets and add to results list
-        results = []
-        to_clear = []
-        for ds in all_datasets:
-            if ds["name"] not in to_keep:
-                results.append([ds["name"], "INTERMEDIATE", "CLEAR", action_status])
-                to_clear.append(ds["name"])
+        # Create df with all results
+        results_df = pd.DataFrame(results, columns=["Dataset", "Type"])
+        results_grouped = results_df.groupby(["Dataset"])['Type'].apply(lambda x: ', '.join(x)).reset_index()
+        results_grouped["Action"] = results_grouped["Dataset"].apply(lambda x: "KEEP" if x in to_keep else "CLEAR")
+        results_grouped["Status"] = action_status
+        results_grouped = results_grouped.sort_values(by=['Action', 'Type'])
+
+        # Perform cleanup
+        to_clear = list(results_grouped["Dataset"][results_grouped['Action']=="CLEAR"])
         logging.info("Total of {} datasets to CLEAR: {}".format(str(len(to_clear)),
                                                                str(to_clear)))
-        # Perform cleanup
+
         if not is_dry_run:
             for ds in to_clear:
                 dataset = project.get_dataset(ds)
                 logging.info("Clearing {}...".format(ds))
                 dataset.clear()
             logging.info("Clearing {} datasets: done.".format(str(len(to_clear))))
-                
-        # Add Inputs, Outputs, Partitioned, and Shared datasets to results list
-        for obj in flow_inputs:
-            results.append([obj, "INPUT", "KEEP", action_status])
-        for obj in flow_outputs:
-            results.append([obj, "OUTPUT", "KEEP", action_status])
-        if keep_partitioned:
-            for obj in partd_datasets:
-                results.append([obj, "PARTITIONED", "KEEP", action_status])
-        if keep_shared:
-            for obj in shared_datasets:
-                results.append([obj, "SHARED", "KEEP", action_status])
-        
-        # Create df with all results
-        columns = ["Dataset", "Type", "Action", "Action Status"]
-        results_df = pd.DataFrame(results, columns=columns)
-        
-        # Group datasets that might belong to more than one type
-        results_grouped = results_df.groupby(["Dataset", "Action", "Action Status"])['Type'].apply(lambda x: ', '.join(x)).reset_index()
-        results_grouped = results_grouped.sort_values(by=['Action', 'Type'])
-        results_grouped = results_grouped.reindex(columns=columns)
-        
+
         # Pass results to result table
         for index, row in results_grouped.iterrows():
             result_table.add_record(list(row))

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -89,7 +89,7 @@ class MyRunnable(Runnable):
                                                            str(shared_datasets)))
 
         # Identify partitioned datasets:
-        is_partitioned = lambda x: len(dataset["partitioning"]["dimensions"]) > 0
+        is_partitioned = lambda dataset: len(dataset["partitioning"]["dimensions"]) > 0
         partitioned_datasets = [dataset["name"] for dataset in all_datasets if is_partitioned(dataset)]
         logging.info("Found {} PARTITIONED datasets: {}".format(str(len(partitioned_datasets)),
                                                                 str(partitioned_datasets)))

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -88,34 +88,34 @@ class MyRunnable(Runnable):
         logging.info("Found {} SHARED datasets: {}".format(str(len(shared_datasets)),
                                                            str(shared_datasets)))
 
-        # Identify partitioned (partd) datasets:
-        is_partd = lambda x: len(x["partitioning"]["dimensions"]) > 0
-        partd_datasets = [x["name"] for x in all_datasets if is_partd(x)]
-        logging.info("Found {} PARTITIONED datasets: {}".format(str(len(partd_datasets)),
-                                                                str(partd_datasets)))
+        # Identify partitioned datasets:
+        is_partitioned = lambda x: len(x["partitioning"]["dimensions"]) > 0
+        partitioned_datasets = [x["name"] for x in all_datasets if is_partitioned(x)]
+        logging.info("Found {} PARTITIONED datasets: {}".format(str(len(partitioned_datasets)),
+                                                                str(partitioned_datasets)))
 
         # Add dataset types to results list
         results = []
 
-        for obj in flow_inputs:
-            results.append([obj, "INPUT"])
+        for dataset in flow_inputs:
+            results.append([dataset, "INPUT"])
 
-        for obj in flow_outputs:
-            results.append([obj, "OUTPUT"])
+        for dataset in flow_outputs:
+            results.append([dataset, "OUTPUT"])
 
-        for obj in intermediate_datasets:
-            results.append([obj, "INTERMEDIATE"])
+        for dataset in intermediate_datasets:
+            results.append([dataset, "INTERMEDIATE"])
 
-        for obj in partd_datasets:
-            results.append([obj, "PARTITIONED"])
+        for dataset in partitioned_datasets:
+            results.append([dataset, "PARTITIONED"])
 
-        for obj in shared_datasets:
-            results.append([obj, "SHARED"])
+        for dataset in shared_datasets:
+            results.append([dataset, "SHARED"])
 
         # Identify which datasets should be kept
         to_keep = flow_inputs + flow_outputs
         if keep_partitioned:
-            to_keep += partd_datasets
+            to_keep += partitioned_datasets
         if keep_shared:
             to_keep += shared_datasets
         logging.info("Total of {} datasets to KEEP: {}".format(str(len(to_keep)),

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -96,21 +96,16 @@ class MyRunnable(Runnable):
 
         # Add dataset types to results list
         results = []
-
-        for dataset in flow_inputs:
-            results.append([dataset, "INPUT"])
-
-        for dataset in flow_outputs:
-            results.append([dataset, "OUTPUT"])
-
-        for dataset in intermediate_datasets:
-            results.append([dataset, "INTERMEDIATE"])
-
-        for dataset in partitioned_datasets:
-            results.append([dataset, "PARTITIONED"])
-
-        for dataset in shared_datasets:
-            results.append([dataset, "SHARED"])
+        
+        datasets = {"INPUT":flow_inputs,
+            "OUTPUT":flow_outputs,
+            "INTERMEDIATE": intermediate_datasets,
+            "SHARED": shared_datasets
+           }
+        
+        for dataset_type, dataset_type_list in datasets.items():
+            for dataset in dataset_type_list:
+                results.append([dataset, dataset_type])
 
         # Identify which datasets should be kept
         to_keep = flow_inputs + flow_outputs

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -83,8 +83,8 @@ class MyRunnable(Runnable):
                                                                 str(intermediate_datasets)))
 
         # Identify shared datasets:
-        shared_objs = project.get_settings().settings["exposedObjects"]["objects"]
-        shared_datasets = [dataset["localName"] for dataset in shared_objs if dataset["type"]=="DATASET"]
+        shared_objects = project.get_settings().settings["exposedObjects"]["objects"]
+        shared_datasets = [dataset["localName"] for dataset in shared_objects if dataset["type"]=="DATASET"]
         logging.info("Found {} SHARED datasets: {}".format(str(len(shared_datasets)),
                                                            str(shared_datasets)))
 

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -70,27 +70,27 @@ class MyRunnable(Runnable):
             append_datasets_to_list(recipe_outputs_dict, output_datasets)
 
         # Identify Flow input/outputs:
-        flow_inputs = [x for x in input_datasets if x not in output_datasets]
-        flow_outputs = [x for x in output_datasets if x not in input_datasets]
+        flow_inputs = [dataset for dataset in input_datasets if dataset not in output_datasets]
+        flow_outputs = [dataset for dataset in output_datasets if dataset not in input_datasets]
         logging.info("Found {} FLOW INPUT datasets: {}".format(str(len(flow_inputs)),
                                                                str(flow_inputs)))
         logging.info("Found {} FLOW OUTPUT datasets: {}".format(str(len(flow_outputs)),
                                                                 str(flow_outputs)))
 
         # Identify Intermediate datasets:
-        intermediate_datasets = [x["name"] for x in all_datasets if x["name"] not in flow_inputs + flow_outputs]
+        intermediate_datasets = [dataset["name"] for dataset in all_datasets if dataset["name"] not in flow_inputs + flow_outputs]
         logging.info("Found {} INTERMEDIATE datasets: {}".format(str(len(intermediate_datasets)),
                                                                 str(intermediate_datasets)))
 
         # Identify shared datasets:
         shared_objs = project.get_settings().settings["exposedObjects"]["objects"]
-        shared_datasets = [x["localName"] for x in shared_objs if x["type"]=="DATASET"]
+        shared_datasets = [dataset["localName"] for dataset in shared_objs if dataset["type"]=="DATASET"]
         logging.info("Found {} SHARED datasets: {}".format(str(len(shared_datasets)),
                                                            str(shared_datasets)))
 
         # Identify partitioned datasets:
-        is_partitioned = lambda x: len(x["partitioning"]["dimensions"]) > 0
-        partitioned_datasets = [x["name"] for x in all_datasets if is_partitioned(x)]
+        is_partitioned = lambda x: len(dataset["partitioning"]["dimensions"]) > 0
+        partitioned_datasets = [dataset["name"] for dataset in all_datasets if is_partitioned(dataset)]
         logging.info("Found {} PARTITIONED datasets: {}".format(str(len(partitioned_datasets)),
                                                                 str(partitioned_datasets)))
 

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -117,9 +117,11 @@ class MyRunnable(Runnable):
             result_table.add_record([obj, "INPUT", "KEEP", action_status])
         for obj in flow_outputs:
             result_table.add_record([obj, "OUTPUT", "KEEP", action_status])
-        for obj in partd_datasets:
-            result_table.add_record([obj, "PARTITIONED", "KEEP", action_status])
-        for obj in shared_datasets:
-            result_table.add_record([obj, "SHARED", "KEEP", action_status])
+        if keep_partitioned:
+            for obj in partd_datasets:
+                result_table.add_record([obj, "PARTITIONED", "KEEP", action_status])
+        if keep_shared:
+            for obj in shared_datasets:
+                result_table.add_record([obj, "SHARED", "KEEP", action_status])
 
         return result_table

--- a/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
+++ b/clear-intermediate-datasets/python-runnables/clear_int_datasets/runnable.py
@@ -84,7 +84,7 @@ class MyRunnable(Runnable):
 
         # Identify shared datasets:
         shared_objects = project.get_settings().settings["exposedObjects"]["objects"]
-        shared_datasets = [dataset["localName"] for dataset in shared_objects if dataset["type"]=="DATASET"]
+        shared_datasets = [object["localName"] for object in shared_objects if object["type"]=="DATASET"]
         logging.info("Found {} SHARED datasets: {}".format(str(len(shared_datasets)),
                                                            str(shared_datasets)))
 


### PR DESCRIPTION
The previous version would list partitioned and shared datasets in the result table regardless of whether 'Keep partitioned datasets' and 'Keep shared datasets' had been selected, hence listing twice a given dataset saying Intermediate - KEEP, and Shared/Partitioned - CLEAR at the same time.