### PR TITLE
[Get US Census Block] Update makefile for deprecation of the plugin

### DIFF
--- a/get-us-census-block/Makefile
+++ b/get-us-census-block/Makefile
@@ -1,4 +1,4 @@
-PLUGIN_VERSION=0.4.1
+PLUGIN_VERSION=0.4.2
 PLUGIN_ID=get-us-census-block
 
 plugin:

--- a/get-us-census-block/plugin.json
+++ b/get-us-census-block/plugin.json
@@ -1,6 +1,6 @@
 {
 	"id" : "get-us-census-block",
-	"version" : "0.4.1",
+	"version" : "0.4.2",
 	"meta" : {
 		"label" : "Get US census block (deprecated)",
 		"description" : "Get an US Census block group from the US Census API. ⚠️ This plugin is now \"deprecated\", we recommend using the [US Census plugin](https://www.dataiku.com/product/plugins/census-us/) instead.",
@@ -8,6 +8,7 @@
 		"icon" : "icon-location-arrow",
 		"licenseInfo" : "Apache Software License",
 		"url": "https://www.dataiku.com/dss/plugins/info/get-us-block.html",
-		"tags": ["Enrichment", "Open Data"]
+		"tags": ["Enrichment", "Open Data"],
+		"deprecated": true
 	}
 }


### PR DESCRIPTION
Story details: [[sc-316795]](https://app.shortcut.com/dataiku/story/316795/mark-get-us-census-block-as-deprecated-and-publish-it-only-on-dss-14-6)

Missed the Makefile version to update, so bumping it too so we can publish (TIL) 