### PR TITLE
[sc-330817][gutenberg] Adds supported Python versions 3.13, 3.14

### DIFF
--- a/gutenberg/CHANGELOG.md
+++ b/gutenberg/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.2.0 - Enhancement release - 2026-07-20
+
+- Added supported Python versions: 3.13, 3.14
+
 ## Version 1.1.2 - Feature release - 2025-05-26
 
 - Removed Python2.7 support

--- a/gutenberg/code-env/python/desc.json
+++ b/gutenberg/code-env/python/desc.json
@@ -1,5 +1,14 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON36", "PYTHON37", "PYTHON39", "PYTHON310", "PYTHON311", "PYTHON312"],
+  "acceptedPythonInterpreters": [
+    "PYTHON36",
+    "PYTHON37",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311",
+    "PYTHON312",
+    "PYTHON313",
+    "PYTHON314"
+  ],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false,

--- a/gutenberg/plugin.json
+++ b/gutenberg/plugin.json
@@ -1,15 +1,18 @@
 {
-    "id": "gutenberg",
-    "version": "1.1.2",
-    "meta": {
-        "label": "Project Gutenberg",
-        "category": "Natural Language Processing",
-        "description": "Download books from Project Gutenberg (https://www.gutenberg.org)",
-        "author": "Dataiku (Hanna Julienne)",
-        "icon": "icon-book",
-        "licenseInfo": "Apache Software License",
-        "url": "https://www.dataiku.com/product/plugins/gutenberg/",
-        "tags": ["Open Data", "NLP"],
-        "supportLevel": "NOT_SUPPORTED"
-    }
+  "id": "gutenberg",
+  "version": "1.2.0",
+  "meta": {
+    "label": "Project Gutenberg",
+    "category": "Natural Language Processing",
+    "description": "Download books from Project Gutenberg (https://www.gutenberg.org)",
+    "author": "Dataiku (Hanna Julienne)",
+    "icon": "icon-book",
+    "licenseInfo": "Apache Software License",
+    "url": "https://www.dataiku.com/product/plugins/gutenberg/",
+    "tags": [
+      "Open Data",
+      "NLP"
+    ],
+    "supportLevel": "NOT_SUPPORTED"
+  }
 }


### PR DESCRIPTION
## ⚠️⚠️⚠️ From an automated update script ⚠️⚠️⚠️

- Support level: `NOT_SUPPORTED`
- Added supported Python versions: `3.13, 3.14`
- Bumped plugin version: `1.2.0`

## Details:
### - Tests on Deployer 14.7.1:
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅
### - Tests on Daily master:
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅