### PR TITLE
[sc-330824][movies-apis] Adds supported Python versions 3.12, 3.13, 3.14

### DIFF
--- a/movies-apis/CHANGELOG.md
+++ b/movies-apis/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.3.0 - Enhancement release - 2026-07-20
+
+- Added supported Python versions: 3.12, 3.13, 3.14
+
 ## Version 0.2.0 - Feature release - 2025-04-17
 
 - Removed Python2.7 and 3.5 support

--- a/movies-apis/code-env/python/desc.json
+++ b/movies-apis/code-env/python/desc.json
@@ -1,5 +1,14 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON36","PYTHON37", "PYTHON39", "PYTHON310", "PYTHON311"],
+  "acceptedPythonInterpreters": [
+    "PYTHON36",
+    "PYTHON37",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311",
+    "PYTHON312",
+    "PYTHON313",
+    "PYTHON314"
+  ],
   "corePackagesSet": "AUTO",
   "forceConda": false,
   "installCorePackages": true,

--- a/movies-apis/plugin.json
+++ b/movies-apis/plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "movies-apis",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "meta": {
     "label": "Enrich from Movies APIs",
     "description": "Fetch data from Open Movie Database and The Movie DB (ratings, runlength, IMDb id, etc)",
@@ -8,22 +8,25 @@
     "icon": "icon-film",
     "licenseInfo": "Apache Software License",
     "url": "https://www.dataiku.com/dss/plugins/info/movies-apis.html",
-    "tags": ["Enrichment", "Open Data"]
+    "tags": [
+      "Enrichment",
+      "Open Data"
+    ]
   },
-  "params":  [
-        {
-          "name": "omdb_api_key",
-          "label": "OMDb API key",
-          "type":  "PASSWORD",
-          "mandatory": false,
-          "description": "API key for the OMDb recipe"
-      },
-      {
-          "name": "tmdb_api_key",
-          "label": "TMDb API key",
-          "type":  "PASSWORD",
-          "mandatory": false,
-          "description": "API key for the TMDb recipe"
-      }
+  "params": [
+    {
+      "name": "omdb_api_key",
+      "label": "OMDb API key",
+      "type": "PASSWORD",
+      "mandatory": false,
+      "description": "API key for the OMDb recipe"
+    },
+    {
+      "name": "tmdb_api_key",
+      "label": "TMDb API key",
+      "type": "PASSWORD",
+      "mandatory": false,
+      "description": "API key for the TMDb recipe"
+    }
   ]
 }


### PR DESCRIPTION
## ⚠️⚠️⚠️ From an automated update script ⚠️⚠️⚠️

- Support level: ``
- Added supported Python versions: `3.12, 3.13, 3.14`
- Bumped plugin version: `0.3.0`

## Details:
### - Tests on Deployer 14.7.1:
 - Creation of Python 3.12 code-env: ✅
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅
### - Tests on Daily master:
 - Creation of Python 3.12 code-env: ✅
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅