### PR TITLE
[sc-330826][musixmatch] Adds supported Python versions 3.13, 3.14

### DIFF
--- a/musixmatch/code-env/python/desc.json
+++ b/musixmatch/code-env/python/desc.json
@@ -1,5 +1,15 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON36", "PYTHON37", "PYTHON38", "PYTHON39", "PYTHON310", "PYTHON311", "PYTHON312"],
+  "acceptedPythonInterpreters": [
+    "PYTHON36",
+    "PYTHON37",
+    "PYTHON38",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311",
+    "PYTHON312",
+    "PYTHON313",
+    "PYTHON314"
+  ],
   "corePackagesSet": "AUTO",
   "forceConda": false,
   "installCorePackages": true,

--- a/musixmatch/plugin.json
+++ b/musixmatch/plugin.json
@@ -1,13 +1,15 @@
 {
-    "id": "musixmatch",
-    "version": "0.0.4",
-    "meta": {
-        "label": "Musixmatch",
-        "description": "Given a list of Musixmatch Artists IDs, retrieves every single track for each artist, with additional details for every track",
-        "author": "Luca Grazioli (ICTeam)",
-        "icon": "icon-music",
-        "licenseInfo": "Apache Software License",
-        "url": "https://www.dataiku.com/product/plugins/musixmatch/",
-        "tags": ["Enrichment"]
-    }
+  "id": "musixmatch",
+  "version": "0.1.0",
+  "meta": {
+    "label": "Musixmatch",
+    "description": "Given a list of Musixmatch Artists IDs, retrieves every single track for each artist, with additional details for every track",
+    "author": "Luca Grazioli (ICTeam)",
+    "icon": "icon-music",
+    "licenseInfo": "Apache Software License",
+    "url": "https://www.dataiku.com/product/plugins/musixmatch/",
+    "tags": [
+      "Enrichment"
+    ]
+  }
 }


### PR DESCRIPTION
## ⚠️⚠️⚠️ From an automated update script ⚠️⚠️⚠️

- Support level: ``
- Added supported Python versions: `3.13, 3.14`
- Bumped plugin version: `0.1.0`

## Details:
INFO: No CHANGELOG.md file
### - Tests on Deployer 14.7.1:
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅
### - Tests on Daily master:
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅